### PR TITLE
Drop dependency on mousepad

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,6 @@ Vcs-Browser: https://github.com/raspberrypi-ui/agnostics
 
 Package: agnostics
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libgtk-3-0 (>= 3.24), mousepad, fio
+Depends: ${shlibs:Depends}, ${misc:Depends}, libgtk-3-0 (>= 3.24), fio
 Description: Raspberry Pi Diagnostics
  Extensible diagnostics package to test Raspberry Pi hardware


### PR DESCRIPTION
Since 625a6eed6cff7d7725a7d619568dd2ffc3975abb changed the editor to the agnostic xdg-open (pun intended), mousepad is no longer necessary as a dependency

As a side note: if this is ever used as a CLI tool, you might use `$EDITOR` (defaults to `nano`) or, even better, just `printf()` the file contents.